### PR TITLE
Redo command line for symlink home

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,4 +5,5 @@ mypy
 pip-tools
 pre-commit
 pytest
+tox
 wheel

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,10 @@ black==19.3b0
 cfgv==2.0.0               # via pre-commit
 click==7.0                # via black, pip-tools
 entrypoints==0.3          # via flake8
+filelock==3.0.12          # via tox
 flake8==3.7.7
 identify==1.4.3           # via pre-commit
 importlib-metadata==0.15  # via pluggy, pre-commit
-importlib-resources==1.0.2  # via pre-commit
 isort==4.3.20
 mccabe==0.6.1             # via flake8
 more-itertools==7.0.0     # via pytest
@@ -23,17 +23,18 @@ mypy-extensions==0.4.1    # via mypy
 mypy==0.701
 nodeenv==1.3.3            # via pre-commit
 pip-tools==3.7.0
-pluggy==0.12.0            # via pytest
+pluggy==0.12.0            # via pytest, tox
 pre-commit==1.16.1
-py==1.8.0                 # via pytest
+py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via flake8
 pyflakes==2.1.1           # via flake8
 pytest==4.5.0
 pyyaml==5.1               # via aspy.yaml, pre-commit
-six==1.12.0               # via cfgv, pip-tools, pre-commit, pytest
-toml==0.10.0              # via black, pre-commit
+six==1.12.0               # via cfgv, pip-tools, pre-commit, pytest, tox
+toml==0.10.0              # via black, pre-commit, tox
+tox==3.12.1
 typed-ast==1.3.5          # via mypy
-virtualenv==16.6.0        # via pre-commit
+virtualenv==16.6.0        # via pre-commit, tox
 wcwidth==0.1.7            # via pytest
 wheel==0.33.4
 zipp==0.5.1               # via importlib-metadata

--- a/scripts/symlink_home.py
+++ b/scripts/symlink_home.py
@@ -1,36 +1,46 @@
 #!/usr/bin/env python3
 import argparse
 import os
+import sys
 from os import path
 from typing import List, Optional
 
 
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="symlink n files to a base path")
+    parser.add_argument("src", help="src directory")
+    parser.add_argument("dest", help="dest directory")
     parser.add_argument("files", metavar="file", nargs="+", help="file to symlink")
-    parser.add_argument("--base_src", required=True, help="base src directory")
-    parser.add_argument("--base_dest", required=True, help="base dest directory")
+    parser.add_argument("-p", "--prefix", help="prefix of the dest filename")
     args = parser.parse_args(argv)
 
-    dotfiles_base = path.abspath(path.dirname(args.base_src))
-    # user might pass something like ~/., need to parse that correctly
-    home = path.dirname(path.expanduser(args.base_dest))
-    pre = path.basename(args.base_dest)
+    src = path.abspath(path.expanduser(args.src))
+    dest = path.dirname(path.expanduser(args.dest))
+    prefix = ""
+    if args.prefix:
+        prefix = args.prefix
     files = args.files
+    retv = 1
     for f in files:
-        h = path.join(home, f"{pre}{f}")
-        # check islink as well in case of broken links
-        if path.lexists(h):
-            r = input(f"{h} exists, overwrite? y[n] ").lower()
+        s = path.join(src, f)
+        if not path.exists(s):
+            print('=== Warning !! ===', file=sys.stderr)
+            print(f'=== {str(s)} does not exist ===', file=sys.stderr)
+            continue
+
+        d = path.join(dest, f"{prefix}{f}")
+        if path.lexists(d):
+            r = input(f"{d} exists, overwrite? y[n] ").lower()
             if "n" == r or "no" == r:
-                print(f"Skipping {f}")
+                print(f'Skipping {f}')
                 continue
             else:
-                os.remove(h)
+                os.remove(d)
                 print(f"Overwritting {f}")
 
-        os.symlink(path.join(dotfiles_base, f), h)
-    return 0
+        os.symlink(s, d)
+        retv = 0
+    return retv
 
 
 if __name__ == "__main__":

--- a/setup.d/12-build-venv.sh
+++ b/setup.d/12-build-venv.sh
@@ -13,8 +13,8 @@ fi
 python3 -m venv venv
 venv/bin/pip install --requirement requirements.txt
 scripts/symlink_home.py  \
-  --base_src "venv/bin/" \
-  --base_dest "$HOME/bin/" \
+  "venv/bin/" \
+  "$HOME/bin/" \
   black \
   flake8 \
   isort \

--- a/setup.d/12-build-venv.sh
+++ b/setup.d/12-build-venv.sh
@@ -23,6 +23,6 @@ scripts/symlink_home.py  \
   pip-compile \
   python \
   pre-commit \
-  pytest \
+  tox \
   virtualenv \
   wheel

--- a/setup.d/13-symlink-dotfiles.sh
+++ b/setup.d/13-symlink-dotfiles.sh
@@ -7,8 +7,9 @@ cd .. || exit 1
 echo "Symlinking Dotfiles"
 
 scripts/symlink_home.py \
-  --base_src "." \
-  --base_dest "$HOME/." \
+  "." \
+  "$HOME/" \
+  --prefix '.' \
   bash_logout \
   bash_profile \
   bashrc \

--- a/test/test_symlink_home.py
+++ b/test/test_symlink_home.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from os import path
+from unittest import mock
 
 import pytest
 
@@ -19,24 +20,45 @@ def base_dirs(tmp_path):
 
 
 def test_link_one(base_dirs):
-    argv = [
-        "--base_src",
-        f"{str(base_dirs.src)}/",
-        "--base_dest",
-        f"{str(base_dirs.dest)}/",
-        "foo",
-    ]
+    argv = [f"{str(base_dirs.src)}/", f"{str(base_dirs.dest)}/", "foo"]
     assert main(argv) == 0
     assert path.lexists(str(base_dirs.dest / "foo"))
 
 
+def test_link_not_exist(base_dirs, capsys):
+    argv = [f"{str(base_dirs.src)}/", f"{str(base_dirs.dest)}/", "bar"]
+    assert main(argv) == 1
+    assert not path.lexists(str(base_dirs.dest / "bar"))
+    _, err = capsys.readouterr()
+    src_bar = str(base_dirs.src / "bar")
+    assert err == ('=== Warning !! ===\n' f'=== {src_bar} does not exist ===\n')
+
+
 def test_link_prefix(base_dirs):
-    argv = [
-        "--base_src",
-        f"{str(base_dirs.src)}/",
-        "--base_dest",
-        f"{str(base_dirs.dest)}/.",
-        "foo",
-    ]
+    argv = [f"{str(base_dirs.src)}/", f"{str(base_dirs.dest)}/", "--prefix", ".", "foo"]
     assert main(argv) == 0
     assert path.lexists(str(base_dirs.dest / ".foo"))
+
+
+def test_link_exists_skip(base_dirs, capsys):
+    dest_foo = base_dirs.dest / ".foo"
+    dest_foo.write_text("foo")
+    argv = [f"{str(base_dirs.src)}/", f"{str(base_dirs.dest)}/", "--prefix", ".", "foo"]
+    with mock.patch('builtins.input') as inp:
+        inp.return_value = 'n'
+        assert main(argv) == 1
+    assert not path.islink(str(base_dirs.dest / ".foo"))
+    out, _ = capsys.readouterr()
+    assert out == f"Skipping foo\n"
+
+
+def test_link_exists_overwrite(base_dirs, capsys):
+    dest_foo = base_dirs.dest / ".foo"
+    dest_foo.write_text("foo")
+    argv = [f"{str(base_dirs.src)}/", f"{str(base_dirs.dest)}/", "--prefix", ".", "foo"]
+    with mock.patch('builtins.input') as inp:
+        inp.return_value = 'y'
+        assert main(argv) == 0
+    assert path.islink(str(base_dirs.dest / ".foo"))
+    out, _ = capsys.readouterr()
+    assert out == f"Overwritting foo\n"


### PR DESCRIPTION
The command line for symlink home made no god damn sense. Now it does.
I also added tests for all the various possibilities with existing files
and what not.