### PR TITLE
Remove ansible symlinks

### DIFF
--- a/ansible/roles/languages/tasks/python.yml
+++ b/ansible/roles/languages/tasks/python.yml
@@ -16,18 +16,7 @@
     state: link
   loop:
     - add-trailing-comma
-    - ansible
-    - ansible-config
-    - ansible-connection
-    - ansible-console
-    - ansible-doc
-    - ansible-galaxy
-    - ansible-inventory
     - ansible-lint
-    - ansible-playbook
-    - ansible-pull
-    - ansible-test
-    - ansible-vault
     - autopep8
     - black
     - flake8


### PR DESCRIPTION
I removed these from the venv in a previous PR so this is just clean up
