### PR TITLE
Update kitty theme

### DIFF
--- a/commitmono/custom-settings.json
+++ b/commitmono/custom-settings.json
@@ -1,0 +1,1 @@
+{"weight":450,"italic":false,"alternates":{"cv01":false,"cv02":true,"cv03":false,"cv04":true,"cv05":true,"cv06":false,"cv07":false,"cv08":false,"cv09":true,"cv10":false,"cv11":false},"features":{"ss01":true,"ss02":true,"ss03":true,"ss04":true,"ss05":true},"letterSpacing":0,"lineHeight":1}

--- a/commitmono/fix.sh
+++ b/commitmono/fix.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Install fonttools for ttx
+python3 -m venv venv
+venv/bin/pip install fonttools
+
+# Convert to ttx
+venv/bin/ttx  ./*.otf
+
+# set isFixedPitch to 1
+sed -i '' -e 's/isFixedPitch value="0"/isFixedPitch value="1"/g' ./*.ttx
+
+# Convert back to otf
+mkdir fixed
+venv/bin/ttx -d fixed/ ./*.ttx
+
+# Copy files in right place for osx
+mv fixed/*.otf ~/Library/Fonts/
+# Refresh font cache
+fc-cache ~/Library/Fonts

--- a/rc.d/kitty/Solarized Dark.conf
+++ b/rc.d/kitty/Solarized Dark.conf
@@ -4,62 +4,98 @@
 ## author: Ethan Schoonover
 ## license: MIT
 ## blurb: Precision colors for machines and people
+## Written for kitty based on the https://github.com/solarized/xresources repo
+
+# Solarized Color key
+# base03        #002b36
+# base02        #073642
+# base01        #586e75
+# base00        #657b83
+# base0         #839496
+# base1         #93a1a1
+# base2         #eee8d5
+# base3         #fdf6e3
+
+# yellow        #b58900
+# orange        #cb4b16
+# red           #dc322f
+# magenta       #d33682
+# violet        #6c71c4
+# blue          #268bd2
+# cyan          #2aa198
+# green         #859900
 
 # The basic colors
 # base0
 foreground              #839496
 # base03
 background              #002b36
+# base03
+selection_foreground    #002b36
 # base1
-selection_foreground    #93a1a1
-# base02
-selection_background    #073642
+selection_background    #93a1a1
 
 # Cursor colors
-# base0
-cursor                  #839496
-# base03
-cursor_text_color       #002b36
+# base1
+cursor                  #93a1a1
+# base01
+cursor_text_color       #586e75
 
 # kitty window border colors
+# orange
 active_border_color     #cb4b16
+# base01
 inactive_border_color   #586e75
 
 # Tab bar colors
+# base03
 active_tab_background   #002b36
+# base0
 active_tab_foreground   #839496
+# base01
 inactive_tab_background #586e75
+# base03
 inactive_tab_foreground #002b36
 
 # The basic 16 colors
 # black
-color0 #eee8d5
-color8 #586e75
+# base02
+color0 #073642
+# base03
+color8 #002b36
 
 # red
 color1 #dc322f
+# orange
 color9 #cb4b16
 
 # green
 color2  #859900
-color10 #93a1a1
+# base01
+color10 #586e75
 
 # yellow
 color3  #b58900
-color11 #839496
+# base00
+color11 #657b83
 
 # blue
 color4  #268bd2
-color12 #657b83
+# base0
+color12 #839496
 
 # magenta
 color5  #d33682
+# violet
 color13 #6c71c4
 
 # cyan
 color6  #2aa198
-color14 #586e75
+# base1
+color14 #93a1a1
 
 # white
+# base2
 color7  #eee8d5
-color15 #002b36
+# base3
+color15 #fdf6e3

--- a/rc.d/kitty/Solarized Light.conf
+++ b/rc.d/kitty/Solarized Light.conf
@@ -4,62 +4,98 @@
 ## author: Ethan Schoonover
 ## license: MIT
 ## blurb: Precision colors for machines and people
+## Written for kitty based on the https://github.com/solarized/xresources repo
+
+# Solarized Color key
+# base03        #002b36
+# base02        #073642
+# base01        #586e75
+# base00        #657b83
+# base0         #839496
+# base1         #93a1a1
+# base2         #eee8d5
+# base3         #fdf6e3
+
+# yellow        #b58900
+# orange        #cb4b16
+# red           #dc322f
+# magenta       #d33682
+# violet        #6c71c4
+# blue          #268bd2
+# cyan          #2aa198
+# green         #859900
 
 # The basic colors
 # base00
 foreground              #657b83
 # base3
 background              #fdf6e3
+# base3
+selection_foreground    #fdf6e3
 # base01
-selection_foreground    #586e75
-# base2
-selection_background    #eee8d5
+selection_background    #586e75
 
 # Cursor colors
-# base00
-cursor                  #657b83
-# base3
-cursor_text_color       #fdf6e3
+# base01
+cursor                  #586e75
+# base1
+cursor_text_color       #93a1a1
 
 # kitty window border colors
+# orange
 active_border_color     #cb4b16
+# base1
 inactive_border_color   #93a1a1
 
 # Tab bar colors
+# base3
 active_tab_background   #fdf6e3
+# base00
 active_tab_foreground   #657b83
+# base1
 inactive_tab_background #93a1a1
+# base3
 inactive_tab_foreground #fdf6e3
 
 # The basic 16 colors
 # black
+# base02
 color0 #073642
-color8 #93a1a1
+# base03
+color8 #002b36
 
 # red
 color1 #dc322f
+# orange
 color9 #cb4b16
 
 # green
 color2  #859900
+# base01
 color10 #586e75
 
 # yellow
 color3  #b58900
+# base00
 color11 #657b83
 
 # blue
 color4  #268bd2
+# base0
 color12 #839496
 
 # magenta
 color5  #d33682
+# violet
 color13 #6c71c4
 
 # cyan
 color6  #2aa198
+# base1
 color14 #93a1a1
 
 # white
+# base2
 color7  #eee8d5
+# base3
 color15 #fdf6e3

--- a/rc.d/kitty/kitty.conf
+++ b/rc.d/kitty/kitty.conf
@@ -1,6 +1,10 @@
 # Cut down from kitty +runpy 'from kitty.config import *; print(commented_out_default_config())'
-
-font_family Hasklig
+# BEGIN_KITTY_FONTS
+font_family      family="CommitMono"
+bold_font        auto
+italic_font      auto
+bold_italic_font auto
+# END_KITTY_FONTS
 
 font_size 13.0
 
@@ -17,5 +21,5 @@ allow_remote_control yes
 
 enabled_layouts vertical,horizontal
 
-# Disable ligatures on highlight -> >>> =>
+# Disable ligatures on highlight -> >>> => != >= ==
 disable_ligatures cursor


### PR DESCRIPTION
## Font Customization:
* Added a commitmono `custom-settings.json`. Set kitty to use commitmono by default.
* Added `fix.sh` script to set `isFixedPitch` to 1. This allows programs to see commitmono as monospace. A bug in the `opentype.js` library strips a bunch of important flags and breaks the downloads. See https://github.com/eigilnikolajsen/commit-mono/issues/15

## Solarized Color Schemes:
* Update the my kitty solarized themes directly from https://github.com/solarized/xresources. Some of the colors were misconfigured. I also greatly cleaned up the kitty.conf theme files to be more understandable..